### PR TITLE
feat(ci): add agent engine update support

### DIFF
--- a/.github/actions/get-agent-engine-id/action.yml
+++ b/.github/actions/get-agent-engine-id/action.yml
@@ -1,0 +1,37 @@
+name: Get Agent Engine ID
+description: Get existing Agent Engine ID by display name
+
+inputs:
+  display_name:
+    description: Display name of the agent
+    required: true
+  region:
+    description: GCP region
+    required: true
+  project_id:
+    description: GCP project ID
+    required: true
+
+outputs:
+  agent_engine_id:
+    description: Agent Engine ID (empty if not found)
+    value: ${{ steps.get.outputs.agent_engine_id }}
+
+runs:
+  using: composite
+  steps:
+    - id: get
+      shell: bash
+      run: |
+        EXISTING_ID=$(gcloud ai reasoning-engines list \
+          --project=${{ inputs.project_id }} \
+          --region=${{ inputs.region }} \
+          --filter="displayName=${{ inputs.display_name }}" \
+          --format="value(name)" \
+          | head -1)
+        echo "agent_engine_id=${EXISTING_ID}" >> $GITHUB_OUTPUT
+        if [ -n "$EXISTING_ID" ]; then
+          echo "Found existing agent: ${EXISTING_ID}"
+        else
+          echo "No existing agent found, will create new"
+        fi

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -84,14 +84,31 @@ jobs:
         run: |
           pip install "google-cloud-aiplatform[adk,agent_engines]>=1.133.0"
 
+      - name: Get existing Agent Engine ID
+        id: existing-agent
+        uses: ./.github/actions/get-agent-engine-id
+        with:
+          display_name: aizap-${{ matrix.agent }}
+          region: ${{ env.REGION }}
+          project_id: ${{ env.PROJECT_ID }}
+
       - name: Deploy ${{ matrix.agent }} to Agent Engine
         working-directory: app/adk/agents
         run: |
           echo "Deploying agent: ${{ matrix.agent }} to ${{ steps.env.outputs.environment }}"
+
+          AGENT_ENGINE_ID_OPT=""
+          if [ -n "${{ steps.existing-agent.outputs.agent_engine_id }}" ]; then
+            echo "Updating existing agent: ${{ steps.existing-agent.outputs.agent_engine_id }}"
+            AGENT_ENGINE_ID_OPT="--agent_engine_id=${{ steps.existing-agent.outputs.agent_engine_id }}"
+          else
+            echo "Creating new agent"
+          fi
 
           adk deploy agent_engine \
             --project=${{ env.PROJECT_ID }} \
             --region=${{ env.REGION }} \
             --staging_bucket=gs://${{ env.PROJECT_ID }}-staging \
             --display_name="aizap-${{ matrix.agent }}" \
+            $AGENT_ENGINE_ID_OPT \
             ${{ matrix.agent }}


### PR DESCRIPTION
## Summary

既存の Agent Engine を更新できるようにして、重複作成を防止

## 変更内容

### 新規ファイル
- `.github/actions/get-agent-engine-id/action.yml`: 既存エージェントの ID を取得

### 修正ファイル
- `.github/workflows/agent-deploy.yml`: 既存エージェント検索 & 更新対応

## 動作

| 状態 | 動作 |
|------|------|
| エージェントが存在しない | 新規作成 |
| エージェントが存在する | 既存を更新 (`--agent_engine_id` 使用) |