### PR TITLE
feat(infra): add ADK agent service account for Agent Engine

### DIFF
--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -104,6 +104,20 @@ module "sa_github_actions" {
   depends_on = [google_project_service.apis]
 }
 
+module "sa_adk_agent" {
+  source = "../modules/service_account"
+
+  project_id   = var.project_id
+  account_id   = "adk-agent-sa"
+  display_name = "adk-agent-sa"
+  description  = "ADK Agent running on Agent Engine"
+  roles = [
+    "roles/aiplatform.user",
+  ]
+
+  depends_on = [google_project_service.apis]
+}
+
 # -----------------------------------------------------------------------------
 # Cloud Storage (Agent Engine Staging)
 # -----------------------------------------------------------------------------

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -104,6 +104,20 @@ module "sa_github_actions" {
   depends_on = [google_project_service.apis]
 }
 
+module "sa_adk_agent" {
+  source = "../modules/service_account"
+
+  project_id   = var.project_id
+  account_id   = "adk-agent-sa"
+  display_name = "adk-agent-sa"
+  description  = "ADK Agent running on Agent Engine"
+  roles = [
+    "roles/aiplatform.user",
+  ]
+
+  depends_on = [google_project_service.apis]
+}
+
 # -----------------------------------------------------------------------------
 # Cloud Storage (Agent Engine Staging)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- ADK Agent Engine 用のカスタムサービスアカウント (`adk-agent-sa`) を作成
- GitHub Actions SA が ADK Agent SA を使用できるよう IAM 権限を付与
- dev / prod 両環境に適用

## Background

現在、Agent Engine にデプロイした ADK エージェントはデフォルトの Vertex AI マネージドサービスアカウント（`service-{PROJECT_NUMBER}@gcp-sa-aiplatform-re.iam.gserviceaccount.com`）で実行されている。

セキュリティと権限管理の観点から、専用のサービスアカウントで実行することが望ましい。

## Changes

### dev/main.tf, prod/main.tf

- `module "sa_adk_agent"`: ADK Agent 用サービスアカウント作成
  - `roles/aiplatform.user` ロール付与
- `google_service_account_iam_member`: GitHub Actions が ADK Agent SA を使用するための権限

## Next Steps

マージ後、フェーズ2 として `.agent_engine_config.json` でサービスアカウントを指定する変更を行う。

## Test plan

- [x] `infra-plan` ワークフローで plan 確認
- [x] マージ後 `infra-release` で apply 成功確認
- [x] GCP コンソールでサービスアカウント作成を確認