### PR TITLE
feat(ci): specify custom service account for Agent Engine deploy

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -92,6 +92,17 @@ jobs:
           region: ${{ env.REGION }}
           project_id: ${{ env.PROJECT_ID }}
 
+      - name: Generate .agent_engine_config.json
+        working-directory: app/adk/agents/${{ matrix.agent }}
+        run: |
+          cat > .agent_engine_config.json << EOF
+          {
+            "service_account": "aizap-adk-sa@${{ env.PROJECT_ID }}.iam.gserviceaccount.com"
+          }
+          EOF
+          echo "Generated .agent_engine_config.json:"
+          cat .agent_engine_config.json
+
       - name: Deploy ${{ matrix.agent }} to Agent Engine
         working-directory: app/adk/agents
         run: |


### PR DESCRIPTION
## Summary

- Agent Engine デプロイ時にカスタムサービスアカウント（`aizap-adk-sa`）を使用するよう設定
- デプロイ前に `.agent_engine_config.json` を動的に生成

## Background

PR #12 で作成した `aizap-adk-sa` サービスアカウントを Agent Engine で使用するための設定。

デフォルトの Vertex AI マネージドサービスアカウント（`service-{PROJECT_NUMBER}@gcp-sa-aiplatform-re.iam.gserviceaccount.com`）ではなく、専用のサービスアカウントで実行することで、権限管理を明確化する。

## Changes

### .github/workflows/agent-deploy.yml

デプロイステップの前に `.agent_engine_config.json` を生成するステップを追加:

```yaml
- name: Generate .agent_engine_config.json
  working-directory: app/adk/agents/${{ matrix.agent }}
  run: |
    cat > .agent_engine_config.json << EOF
    {
      "service_account": "aizap-adk-sa@${{ env.PROJECT_ID }}.iam.gserviceaccount.com"
    }
    EOF
```

ADK CLI は `.agent_engine_config.json` を自動的に読み込み、`service_account` パラメータを Vertex AI SDK に渡す。

## Test plan

- [x] ワークフロー実行でエラーが出ないこと
- [x] Agent Engine コンソールでサービスアカウントが `aizap-adk-sa` に変更されていること