### PR TITLE
fix(infra): grant Vertex AI Service Agent GCS read permission for multimodal

### DIFF
--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -19,6 +19,14 @@ provider "google" {
 }
 
 # -----------------------------------------------------------------------------
+# Data Sources
+# -----------------------------------------------------------------------------
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# -----------------------------------------------------------------------------
 # Local Variables
 # -----------------------------------------------------------------------------
 
@@ -181,6 +189,16 @@ resource "google_storage_bucket_iam_member" "line_media_adk_viewer" {
   member = "serviceAccount:${module.sa_adk_agent.email}"
 
   depends_on = [google_project_service.apis, module.sa_adk_agent, google_storage_bucket.line_media]
+}
+
+# Vertex AI Service Agent が GCS からメディアを読み取るための権限
+# Gemini が file_data で GCS URI を読み取る際に使用される
+resource "google_storage_bucket_iam_member" "line_media_vertex_ai" {
+  bucket = google_storage_bucket.line_media.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.apis, google_storage_bucket.line_media]
 }
 
 # -----------------------------------------------------------------------------

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -19,6 +19,14 @@ provider "google" {
 }
 
 # -----------------------------------------------------------------------------
+# Data Sources
+# -----------------------------------------------------------------------------
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# -----------------------------------------------------------------------------
 # Local Variables
 # -----------------------------------------------------------------------------
 
@@ -181,6 +189,16 @@ resource "google_storage_bucket_iam_member" "line_media_adk_viewer" {
   member = "serviceAccount:${module.sa_adk_agent.email}"
 
   depends_on = [google_project_service.apis, module.sa_adk_agent, google_storage_bucket.line_media]
+}
+
+# Vertex AI Service Agent が GCS からメディアを読み取るための権限
+# Gemini が file_data で GCS URI を読み取る際に使用される
+resource "google_storage_bucket_iam_member" "line_media_vertex_ai" {
+  bucket = google_storage_bucket.line_media.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.apis, google_storage_bucket.line_media]
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## 目的 / 背景

Gemini がマルチモーダル入力（画像・音声・動画）を `file_data` で受け取る際、Vertex AI Service Agent が GCS バケットへのアクセス権限を必要とする。この権限が不足していたため、画像を送信しても「画像を直接拝見することができない」というエラーが発生していた。

## 変更の概要

- **インフラストラクチャ**:
  - `data.google_project` データソースを追加（プロジェクト番号取得用）
  - `line_media` バケットに Vertex AI Service Agent (`service-{PROJECT_NUMBER}@gcp-sa-aiplatform.iam.gserviceaccount.com`) の `roles/storage.objectViewer` 権限を追加
  - dev / prod 両環境に適用

## 確認手順

1. `terraform plan` で変更内容を確認
2. `terraform apply` で適用
3. LINE から画像を送信し、エージェントが画像の内容を認識できることを確認

## 影響 / 互換性

- GCS バケットの IAM ポリシーに新しいメンバーを追加
- 既存の機能への影響なし
- 破壊的変更なし

## チェックリスト

- [x] Conventional Commit 形式のコミットメッセージ
- [x] ベースブランチ: main
- [x] `terraform fmt -check` 通過