### PR TITLE
perf(infra): enable startup_cpu_boost for Cloud Run services

### DIFF
--- a/infra/modules/cloud_run/main.tf
+++ b/infra/modules/cloud_run/main.tf
@@ -48,6 +48,8 @@ resource "google_cloud_run_v2_service" "this" {
           cpu    = "1"
           memory = "512Mi"
         }
+        # コールドスタート時に CPU を一時的に増強（1 vCPU → 2 vCPU）して起動を高速化
+        startup_cpu_boost = true
       }
 
       dynamic "startup_probe" {


### PR DESCRIPTION
## 概要

Cloud Run のコールドスタート時間を短縮するため、`startup_cpu_boost` を有効化。

## 変更内容

- Cloud Run モジュールで `startup_cpu_boost = true` を設定
- コールドスタート時に CPU を一時的に 2 倍に増強（1 vCPU → 2 vCPU）
- 起動 + 10 秒間のみ追加 CPU が割り当てられる

## 公式ドキュメント

- [Configure CPU limits for services | Cloud Run](https://cloud.google.com/run/docs/configuring/services/cpu#startup-boost)