### PR TITLE
feat (schema): add ExerciseLog schema and table

### DIFF
--- a/app/worker/prisma/ExerciseLog-schema.md
+++ b/app/worker/prisma/ExerciseLog-schema.md
@@ -119,7 +119,6 @@ type SetRecord = {
 | Primary Key | `id` | レコードの一意識別 |
 | Index 1 | `user_id`, `recorded_at DESC` | ユーザーの最新記録を高速取得 |
 | Index 2 | `user_id`, `exercise_name`, `recorded_at DESC` | 特定種目の履歴を高速取得 |
-| Index 3 | `user_id`, `category` | カテゴリ別の集計を高速化 |
 
 ## リレーション
 

--- a/app/worker/prisma/migrations/20260130094155_add_exercise_logs_table/migration.sql
+++ b/app/worker/prisma/migrations/20260130094155_add_exercise_logs_table/migration.sql
@@ -24,8 +24,5 @@ CREATE INDEX "exercise_logs_user_id_recorded_at_idx" ON "exercise_logs"("user_id
 -- CreateIndex
 CREATE INDEX "exercise_logs_user_id_exercise_name_recorded_at_idx" ON "exercise_logs"("user_id", "exercise_name", "recorded_at" DESC);
 
--- CreateIndex
-CREATE INDEX "exercise_logs_user_id_category_idx" ON "exercise_logs"("user_id", "category");
-
 -- AddForeignKey
 ALTER TABLE "exercise_logs" ADD CONSTRAINT "exercise_logs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user_sessions"("user_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/app/worker/prisma/schema.prisma
+++ b/app/worker/prisma/schema.prisma
@@ -48,5 +48,4 @@ model ExerciseLog {
   @@map("exercise_logs")
   @@index([userId, recordedAt(sort: Desc)])
   @@index([userId, exerciseName, recordedAt(sort: Desc)])
-  @@index([userId, category])
 }


### PR DESCRIPTION
## 対応Issue
https://github.com/heyhey1028/aizap/issues/57

### 用途
`exercise_logs` は、ユーザーの運動記録（筋トレ/有酸素/柔軟など）を **種目＋セット詳細（JSON）** で保持し、履歴表示や集計（セット数・回数・距離・時間・ボリューム）を高速に扱うためのテーブルです。`user_sessions` に紐づき、ユーザー削除時はログも **CASCADE** で削除されます。

### テーブル / フィールド定義（`exercise_logs`）

| フィールド | DB型 | Nullable | 用途 |
|---|---|---:|---|
| `id` | `TEXT` | ✗ | 運動ログID |
| `user_id` | `TEXT` | ✗ | ユーザー紐づけ |
| `exercise_name` | `TEXT` | ✗ | 種目名（例: `running`, `bench_press`） |
| `sets` | `JSONB` | ✗ | セット配列（重量/回数・時間/距離など） |
| `category` | `TEXT` | ✓ | カテゴリ（`strength`/`cardio`/`flexibility`） |
| `muscle_group` | `TEXT` | ✓ | 対象筋群（例: `chest`, `back` 等） |
| `total_sets` | `INTEGER` | ✗ | 合計セット数 |
| `total_reps` | `INTEGER` | ✓ | 合計回数（主に筋トレ） |
| `total_duration` | `INTEGER` | ✓ | 合計時間（分） |
| `total_distance` | `DOUBLE PRECISION` | ✓ | 合計距離（km） |
| `total_volume` | `DOUBLE PRECISION` | ✓ | 合計ボリューム（重量×回数） |
| `note` | `TEXT` | ✓ | メモ |
| `recorded_at` | `TIMESTAMP(3)` | ✗ | 実施日時 |
| `created_at` | `TIMESTAMP(3)` | ✗ | 作成日時 |
※ 詳細はマークダウン参照 


### インデックス
- **(user_id, recorded_at DESC)**: ユーザーの最新ログ取得を高速化
- **(user_id, exercise_name, recorded_at DESC)**: 種目別の履歴取得を高速化