### PR TITLE
feat(infra): ユーザーアカウント（開発者）に対する ADK サービスアカウントのなりすましを許可 [dev]

### DIFF
--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -138,6 +138,15 @@ module "sa_adk_agent" {
   depends_on = [google_project_service.apis]
 }
 
+# 開発者がローカルから ADK サービスアカウントになりすませるようにする
+resource "google_service_account_iam_member" "adk_agent_token_creator" {
+  service_account_id = module.sa_adk_agent.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "allAuthenticatedUsers"
+
+  depends_on = [module.sa_adk_agent]
+}
+
 # -----------------------------------------------------------------------------
 # Cloud Storage (Agent Engine Staging)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
ref: #63 

## Summary

- 開発者がローカルから `aizap-adk-sa` を偽装して Cloud SQL に接続できるようにする
- ADK の DB アクセス層をローカルでテスト可能にするための前提条件

## 変更内容

`infra/dev/main.tf` に以下を追加:

```hcl
resource "google_service_account_iam_member" "adk_agent_token_creator" {
  service_account_id = module.sa_adk_agent.id
  role               = "roles/iam.serviceAccountTokenCreator"
  member             = "allAuthenticatedUsers"
}
```

## 使用方法

```bash
gcloud auth application-default login \
  --impersonate-service-account=aizap-adk-sa@aizap-dev.iam.gserviceaccount.com
```

## 注意

- `allAuthenticatedUsers` は GCP にログインしている全ユーザーが偽装可能
- 開発環境 (dev) のみで使用