### PR TITLE
feat(infra): ユーザーアカウント（開発者）に対する ADK サービスアカウントのなりすましを許可 [prod]

### DIFF
--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -138,6 +138,17 @@ module "sa_adk_agent" {
   depends_on = [google_project_service.apis]
 }
 
+# 開発者がローカルから ADK サービスアカウントを偽装できるようにする
+# gcloud auth application-default login --impersonate-service-account=aizap-adk-sa@PROJECT.iam.gserviceaccount.com
+# 注意: allAuthenticatedUsers は GCP にログインしている全ユーザーが偽装可能
+resource "google_service_account_iam_member" "adk_agent_token_creator" {
+  service_account_id = module.sa_adk_agent.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "allAuthenticatedUsers"
+
+  depends_on = [module.sa_adk_agent]
+}
+
 # -----------------------------------------------------------------------------
 # Cloud Storage (Agent Engine Staging)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
ref: #63 

## Summary

- prod 環境でも `aizap-adk-sa` を偽装して Cloud SQL に接続できるようにする
- dev 環境と同様の設定を prod に追加

## 変更内容

`infra/prod/main.tf` に以下を追加:

```hcl
resource "google_service_account_iam_member" "adk_agent_token_creator" {
  service_account_id = module.sa_adk_agent.id
  role               = "roles/iam.serviceAccountTokenCreator"
  member             = "allAuthenticatedUsers"
}
```

## 関連 PR

- #62 (dev 環境)