### PR TITLE
feat(infra): ADK サービスアカウントに serviceUsageConsumer ロールを追加

### DIFF
--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -133,6 +133,7 @@ module "sa_adk_agent" {
     "roles/aiplatform.user",
     "roles/cloudsql.client",
     "roles/cloudsql.instanceUser",
+    "roles/serviceusage.serviceUsageConsumer",
   ]
 
   depends_on = [google_project_service.apis]

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -133,6 +133,7 @@ module "sa_adk_agent" {
     "roles/aiplatform.user",
     "roles/cloudsql.client",
     "roles/cloudsql.instanceUser",
+    "roles/serviceusage.serviceUsageConsumer",
   ]
 
   depends_on = [google_project_service.apis]


### PR DESCRIPTION
ref: #63, #65

## Summary
- ADK サービスアカウント (`aizap-adk-sa`) に `roles/serviceusage.serviceUsageConsumer` を追加
- Cloud SQL Connector が Cloud SQL Admin API を呼び出すために必要

## 変更ファイル
- `infra/dev/main.tf`
- `infra/prod/main.tf`

Made with [Cursor](https://cursor.com)