### PR TITLE
feat: add asset bucket

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -41,10 +41,10 @@ export DB_NAME=aizap
 
 ## ADK コマンド
 
-| コマンド | 説明 | セッション |
-|---------|------|-----------|
-| `uv run adk web` | ブラウザベース開発 UI | InMemorySessionService |
-| `uv run adk run` | ターミナル対話型テスト | InMemorySessionService |
+| コマンド                | 説明                       | セッション             |
+| ----------------------- | -------------------------- | ---------------------- |
+| `uv run adk web`        | ブラウザベース開発 UI      | InMemorySessionService |
+| `uv run adk run`        | ターミナル対話型テスト     | InMemorySessionService |
 | `uv run adk api_server` | ローカル REST API サーバー | InMemorySessionService |
 
 ### 実行例
@@ -67,12 +67,12 @@ uv run adk api_server agents/health_advisor
 
 ブラウザで http://localhost:8000 にアクセスすると、開発用 UI が表示されます。
 
-| 項目 | 説明 |
-|------|------|
-| Agent ドロップダウン | テストするエージェントを選択 |
-| SESSION ID | 現在のセッション ID（自動生成） |
-| **USER ID** | ユーザー ID（デフォルト: `user`、クリックして変更可能） |
-| + New Session | 新しいセッションを開始 |
+| 項目                 | 説明                                                    |
+| -------------------- | ------------------------------------------------------- |
+| Agent ドロップダウン | テストするエージェントを選択                            |
+| SESSION ID           | 現在のセッション ID（自動生成）                         |
+| **USER ID**          | ユーザー ID（デフォルト: `user`、クリックして変更可能） |
+| + New Session        | 新しいセッションを開始                                  |
 
 **ヒント**: `USER ID` 欄はクリックして任意の値に変更できます。DB テスト時は `local-test-user` などに変更すると、本番データと区別しやすくなります。
 
@@ -166,3 +166,12 @@ terraform plan \
 
 > **Note**: `image_*` には現在デプロイ中のイメージを指定してください。
 > GitHub Actions では自動で現在のイメージを取得します。
+
+## 公開アセット用バケット（画像アップロード）
+
+公開アセット用バケット（`${project_id}-asset`）へ画像をアップロードする例：
+
+```bash
+PROJECT_ID=aizap-prod
+gcloud storage cp image.png gs://${PROJECT_ID}-asset/
+```

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -225,6 +225,31 @@ resource "google_project_iam_member" "vertex_ai_service_usage" {
 }
 
 # -----------------------------------------------------------------------------
+# Cloud Storage (Public Asset)
+# -----------------------------------------------------------------------------
+
+resource "google_storage_bucket" "public_asset" {
+  project                     = var.project_id
+  name                        = "${var.project_id}-asset"
+  location                    = "ASIA1"
+  storage_class               = "STANDARD"
+  force_destroy               = false
+  uniform_bucket_level_access = true
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_storage_bucket_iam_binding" "public_asset_iam_binding" {
+  bucket = google_storage_bucket.public_asset.name
+  role   = "roles/storage.legacyObjectReader"
+  members = [
+    "allUsers",
+  ]
+
+  depends_on = [google_project_service.apis, google_storage_bucket.public_asset]
+}
+
+# -----------------------------------------------------------------------------
 # Artifact Registry
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## 概要

外部公開用のアセット用 GCS バケットを **prod 環境のみ** に Terraform で追加し、開発ガイドに画像アップロード例を追記した。

## 変更内容

### Terraform（infra/prod/main.tf）

- **Cloud Storage (Public Asset)** セクションを追加
  - バケット名: `${var.project_id}-asset`
  - ロケーション: `ASIA1`（東京・大阪デュアルリージョン）
  - `force_destroy = false`、`uniform_bucket_level_access = true`
  - IAM: `roles/storage.legacyObjectReader` を `allUsers` に付与（オブジェクトの公開読み取り）

### ドキュメント（docs/development.md）

- **公開アセット用バケット（画像アップロード）** セクションを追加
  - `gcloud storage cp` で画像をアップロードするコマンド例を 1 つ記載

## 備考

- 利用は限定的なため、バケットは **prod のみ** 作成（dev には追加していない）
- アップロード後、オブジェクトは `https://storage.googleapis.com/<project_id>-asset/<object>` で未認証アクセス可能