### PR TITLE
fix: adk-sa への PostgreSQL テーブル権限付与を自動化

### DIFF
--- a/app/worker/prisma/migrations/20260205000000_grant_adk_sa_permissions/migration.sql
+++ b/app/worker/prisma/migrations/20260205000000_grant_adk_sa_permissions/migration.sql
@@ -1,0 +1,28 @@
+-- ADK サービスアカウントに PostgreSQL テーブル権限を付与
+-- マイグレーションは worker-sa で実行されるため、テーブルのオーナーは worker-sa になる
+-- ADK は adk-sa で接続するため、明示的な GRANT が必要
+
+DO $$
+BEGIN
+  -- dev 環境
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'aizap-adk-sa@aizap-dev.iam') THEN
+    -- 既存テーブルへの権限付与
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public 
+      TO "aizap-adk-sa@aizap-dev.iam";
+    -- 今後作成されるテーブルへの権限自動付与
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public
+      GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES 
+      TO "aizap-adk-sa@aizap-dev.iam";
+  END IF;
+  
+  -- prod 環境
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'aizap-adk-sa@aizap-prod.iam') THEN
+    -- 既存テーブルへの権限付与
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public 
+      TO "aizap-adk-sa@aizap-prod.iam";
+    -- 今後作成されるテーブルへの権限自動付与
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public
+      GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES 
+      TO "aizap-adk-sa@aizap-prod.iam";
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- ADK サービスアカウントに PostgreSQL テーブルへの権限を付与するマイグレーションを追加
- 既存テーブルへの権限付与 + 今後作成されるテーブルへの自動権限付与

## Background
- Cloud SQL で IAM 認証を使用しており、マイグレーションは worker-sa で実行
- ADK は adk-sa で接続するため、明示的な GRANT が必要
- これまで手動で SQL Studio から権限付与していたが、自動化する