### PR TITLE
feat(adk): Add global endpoint workaround for Gemini 3.0 Flash

### DIFF
--- a/app/adk/agents/health_advisor/agent.py
+++ b/app/adk/agents/health_advisor/agent.py
@@ -1,6 +1,7 @@
 from google.adk.agents import Agent
 from google.adk.tools import AgentTool
 
+from .models import GeminiGlobal
 from .schemas import RootAgentOutput
 from .sub_agents import (
     goal_setting_agent,
@@ -12,7 +13,7 @@ from .sub_agents import (
 
 # root agent
 root_agent = Agent(
-    model="gemini-2.5-flash",
+    model=GeminiGlobal(model="gemini-3.0-flash"),
     name="root_agent",
     description="「aizap」健康アドバイザーのメインエージェント",
     instruction="""あなたは「aizap」健康アドバイザーのメインアシスタントです。

--- a/app/adk/agents/health_advisor/agent.py
+++ b/app/adk/agents/health_advisor/agent.py
@@ -13,7 +13,7 @@ from .sub_agents import (
 
 # root agent
 root_agent = Agent(
-    model=GeminiGlobal(model="gemini-3.0-flash"),
+    model=GeminiGlobal(model="gemini-3-flash-preview"),
     name="root_agent",
     description="「aizap」健康アドバイザーのメインエージェント",
     instruction="""あなたは「aizap」健康アドバイザーのメインアシスタントです。

--- a/app/adk/agents/health_advisor/models.py
+++ b/app/adk/agents/health_advisor/models.py
@@ -24,7 +24,7 @@ class GeminiGlobal(Gemini):
     使用例:
     ```python
     agent = Agent(
-        model=GeminiGlobal(model="gemini-3.0-flash"),
+        model=GeminiGlobal(model="gemini-3-flash-preview"),
         name="my_agent",
         ...
     )

--- a/app/adk/agents/health_advisor/models.py
+++ b/app/adk/agents/health_advisor/models.py
@@ -1,0 +1,54 @@
+"""カスタム Gemini モデルクラス
+
+Gemini 3.0 Flash など、グローバルエンドポイントが必要なモデル向けのワークアラウンド。
+標準の Gemini クラスではリージョナルエンドポイントの解決に失敗するため、
+location="global" を明示的に指定してクライアントを初期化する。
+
+参考: https://github.com/google/adk-python/issues/1095
+"""
+
+import os
+from functools import cached_property
+
+from google.adk.models import Gemini
+from google.genai import Client, types
+
+
+class GeminiGlobal(Gemini):
+    """グローバルエンドポイントを使用する Gemini モデル。
+
+    通常の Gemini クラスではデフォルトのロケーション解決ロジックにより、
+    特定のモデル（gemini-3.0-flash 等）でデプロイに失敗する場合がある。
+    このサブクラスでは Client に project と location="global" を明示的に渡すことで回避する。
+
+    使用例:
+    ```python
+    agent = Agent(
+        model=GeminiGlobal(model="gemini-3.0-flash"),
+        name="my_agent",
+        ...
+    )
+    ```
+    """
+
+    @cached_property
+    def api_client(self) -> Client:
+        """明示的な設定で API クライアントを提供する。
+
+        Returns:
+            グローバルエンドポイントで初期化された API クライアント。
+        """
+        project = os.getenv("GOOGLE_CLOUD_PROJECT")
+        if not project:
+            raise ValueError(
+                "GOOGLE_CLOUD_PROJECT 環境変数が設定されていません。"
+            )
+
+        return Client(
+            project=project,
+            location="global",
+            http_options=types.HttpOptions(
+                headers=self._tracking_headers(),
+                retry_options=self.retry_options,
+            ),
+        )

--- a/app/adk/agents/health_advisor/sub_agents/exercise_manager.py
+++ b/app/adk/agents/health_advisor/sub_agents/exercise_manager.py
@@ -23,7 +23,7 @@ from ..tools.util_tools import finish_task, get_current_goal
 
 exercise_manager_agent = Agent(
     name="exercise_manager_agent",
-    model=GeminiGlobal(model="gemini-3.0-flash"),
+    model=GeminiGlobal(model="gemini-3-flash-preview"),
     description="運動記録の保存・取得、運動習慣計画の作成・管理を行う熱血コーチ。運動報告を受けて記録し、習慣化をサポートし、モチベーションを上げる言葉で励ます。",
     instruction="""あなたは「燃えるコーチ」だ！！！
 パッション溢れる熱血コーチとして、ユーザーの運動をサポートする。

--- a/app/adk/agents/health_advisor/sub_agents/exercise_manager.py
+++ b/app/adk/agents/health_advisor/sub_agents/exercise_manager.py
@@ -5,6 +5,7 @@
 
 from google.adk.agents import Agent
 
+from ..models import GeminiGlobal
 from ..schemas import ExerciseManagerAgentOutput
 from ..tools.exercise_log_tools import (
     create_exercise_log,
@@ -22,7 +23,7 @@ from ..tools.util_tools import finish_task, get_current_goal
 
 exercise_manager_agent = Agent(
     name="exercise_manager_agent",
-    model="gemini-2.5-flash",
+    model=GeminiGlobal(model="gemini-3.0-flash"),
     description="運動記録の保存・取得、運動習慣計画の作成・管理を行う熱血コーチ。運動報告を受けて記録し、習慣化をサポートし、モチベーションを上げる言葉で励ます。",
     instruction="""あなたは「燃えるコーチ」だ！！！
 パッション溢れる熱血コーチとして、ユーザーの運動をサポートする。

--- a/app/adk/agents/health_advisor/sub_agents/meal_record.py
+++ b/app/adk/agents/health_advisor/sub_agents/meal_record.py
@@ -5,6 +5,7 @@ from google.adk.agents import Agent
 from google.adk.tools import ToolContext
 
 from ..db.config import get_async_session
+from ..models import GeminiGlobal
 from ..schemas import MealRecordAgentOutput
 from ..db.repositories import DietLogRepository
 from ..logger import get_logger
@@ -562,7 +563,7 @@ async def record_meal(
 
 # sub agent
 meal_record_agent = Agent(
-    model="gemini-2.5-flash",
+    model=GeminiGlobal(model="gemini-3.0-flash"),
     name="meal_record_agent",
     description="食事の記録・管理を担当。「〇〇を食べた」「記録して」「何食べればいい？」「レシピ教えて」等に対応。画像からの食事分析も可能。",
     instruction="""あなたは「ギャル栄養士」キャラの食事記録サポーターです。

--- a/app/adk/agents/health_advisor/sub_agents/meal_record.py
+++ b/app/adk/agents/health_advisor/sub_agents/meal_record.py
@@ -563,7 +563,7 @@ async def record_meal(
 
 # sub agent
 meal_record_agent = Agent(
-    model=GeminiGlobal(model="gemini-3.0-flash"),
+    model=GeminiGlobal(model="gemini-3-flash-preview"),
     name="meal_record_agent",
     description="食事の記録・管理を担当。「〇〇を食べた」「記録して」「何食べればいい？」「レシピ教えて」等に対応。画像からの食事分析も可能。",
     instruction="""あなたは「ギャル栄養士」キャラの食事記録サポーターです。


### PR DESCRIPTION
## Summary

- Add `GeminiGlobal` subclass that overrides `api_client` to explicitly set `location="global"`, working around the regional endpoint resolution issue with Gemini 3.0 models
- Update all agents (root / exercise_manager / meal_record) from `gemini-2.5-flash` to `gemini-3.0-flash`
- Fix a bug in the original workaround where `_tracking_headers` was missing `()` (it's a method, not a property)

### Background

The standard `Gemini` class initializes `Client()` with default location resolution, which fails for Gemini 3.0 models that require the global endpoint.

ref: https://github.com/google/adk-python/issues/3628#issuecomment-3595215761

## Changed Files

| File | Change |
|---|---|
| `models.py` | **New** - `GeminiGlobal` class |
| `agent.py` | Add import + change model to `GeminiGlobal(model="gemini-3.0-flash")` |
| `sub_agents/exercise_manager.py` | Same as above |
| `sub_agents/meal_record.py` | Same as above |